### PR TITLE
chore(amqp): upgrade amqplib to v1.0.3

### DIFF
--- a/.changeset/amqplib-v1-upgrade.md
+++ b/.changeset/amqplib-v1-upgrade.md
@@ -1,0 +1,5 @@
+---
+"@effect-messaging/amqp": patch
+---
+
+Upgrade amqplib peer dependency from ^0.10.9 to ^1.0.0 and @types/amqplib from 0.10.7 to 0.10.8

--- a/packages/amqp/package.json
+++ b/packages/amqp/package.json
@@ -41,14 +41,14 @@
   "devDependencies": {
     "@effect-messaging/core": "workspace:^",
     "@effect/platform": "^0.96.0",
-    "@types/amqplib": "0.10.7",
-    "amqplib": "^0.10.9",
+    "@types/amqplib": "0.10.8",
+    "amqplib": "^1.0.0",
     "effect": "^3.21.0"
   },
   "peerDependencies": {
     "@effect-messaging/core": "workspace:^",
     "@effect/platform": "^0.94.5",
-    "amqplib": "^0.10.9",
+    "amqplib": "^1.0.0",
     "effect": "^3.19.19"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,11 +111,11 @@ importers:
         specifier: ^0.96.0
         version: 0.96.0(effect@3.21.0)
       '@types/amqplib':
-        specifier: 0.10.7
-        version: 0.10.7
+        specifier: 0.10.8
+        version: 0.10.8
       amqplib:
-        specifier: ^0.10.9
-        version: 0.10.9
+        specifier: ^1.0.0
+        version: 1.0.3
       effect:
         specifier: ^3.21.0
         version: 3.21.0
@@ -862,8 +862,8 @@ packages:
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
-  '@types/amqplib@0.10.7':
-    resolution: {integrity: sha512-IVj3avf9AQd2nXCx0PGk/OYq7VmHiyNxWFSb5HhU9ATh+i+gHWvVcljFTcTWQ/dyHJCTrzCixde+r/asL2ErDA==}
+  '@types/amqplib@0.10.8':
+    resolution: {integrity: sha512-vtDp8Pk1wsE/AuQ8/Rgtm6KUZYqcnTgNvEHwzCkX8rL7AGsC6zqAfKAAJhUZXFhM/Pp++tbnUHiam/8vVpPztA==}
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
@@ -1253,9 +1253,9 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
-  amqplib@0.10.9:
-    resolution: {integrity: sha512-jwSftI4QjS3mizvnSnOrPGYiUnm1vI2OP1iXeOUz5pb74Ua0nbf6nPyyTzuiCLEE3fMpaJORXh2K/TQ08H5xGA==}
-    engines: {node: '>=10'}
+  amqplib@1.0.3:
+    resolution: {integrity: sha512-nsrXa59tvX4HPjPPW8JJGuBb/Db0MOq3DOhGdSbIY7bTsQDMV2fmF9c3i74g/8Gt9+QWyrxfEPppOOoV9lK1uQ==}
+    engines: {node: '>=18'}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -2794,9 +2794,6 @@ packages:
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
-  querystringify@2.2.0:
-    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
-
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -2855,9 +2852,6 @@ packages:
     resolution: {integrity: sha512-DouTG8T1WanGok6Qjg2SXuCMzszOo0eHeH9hDZ5Y4x8Je+9JB38HdTLT4/VA8OaUhBa0JPVHJ0pyBkM1z+pDsw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  requires-port@1.0.0:
-    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
   resolve-dependency-path@4.0.1:
     resolution: {integrity: sha512-YQftIIC4vzO9UMhO/sCgXukNyiwVRCVaxiWskCBy7Zpqkplm8kTAISZ8O1MoKW1ca6xzgLUBjZTcDgypXvXxiQ==}
@@ -3237,9 +3231,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  url-parse@1.5.10:
-    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -4127,7 +4118,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@types/amqplib@0.10.7':
+  '@types/amqplib@0.10.8':
     dependencies:
       '@types/node': 24.9.1
 
@@ -4571,10 +4562,9 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  amqplib@0.10.9:
+  amqplib@1.0.3:
     dependencies:
       buffer-more-ints: 1.0.0
-      url-parse: 1.5.10
 
   ansi-colors@4.1.3: {}
 
@@ -6324,8 +6314,6 @@ snapshots:
 
   quansync@0.2.11: {}
 
-  querystringify@2.2.0: {}
-
   queue-microtask@1.2.3: {}
 
   quote-unquote@1.0.0: {}
@@ -6408,8 +6396,6 @@ snapshots:
       stringify-object: 3.3.0
 
   requirejs@2.3.7: {}
-
-  requires-port@1.0.0: {}
 
   resolve-dependency-path@4.0.1: {}
 
@@ -6874,11 +6860,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  url-parse@1.5.10:
-    dependencies:
-      querystringify: 2.2.0
-      requires-port: 1.0.0
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## Summary

- Upgrade `amqplib` peer and dev dependency from `^0.10.9` to `^1.0.0` (resolves to `1.0.3`, the latest)
- Upgrade `@types/amqplib` from `0.10.7` to `0.10.8`

## Migration Notes

The `v1.0.0` release contains no API-level breaking changes — all changes are internal code quality improvements (formatting, linting, modernisation). The only breaking change is the minimum Node.js requirement bumped to v18, which is satisfied by this project's engine requirement of Node 24.

## Checklist

- [x] Build passes
- [x] Type check passes
- [x] All 14 tests pass
- [x] Changeset added (patch)