### PR TITLE
feat(core): add producerSpanRelation subscriber option

### DIFF
--- a/.changeset/new-trace-per-message.md
+++ b/.changeset/new-trace-per-message.md
@@ -1,0 +1,9 @@
+---
+"@effect-messaging/core": minor
+"@effect-messaging/amqp": minor
+"@effect-messaging/nats": minor
+---
+
+Add `newTracePerMessage` subscriber option. When enabled, each consumed message handler runs in a new root span, and the span extracted from the message headers (e.g. W3C `traceparent`) is attached as a `SpanLink` instead of being used as the parent.
+
+The option is opt-in and defaults to `false` (legacy behavior: extracted span is used as the parent of the consumer span).

--- a/.changeset/new-trace-per-message.md
+++ b/.changeset/new-trace-per-message.md
@@ -1,9 +1,0 @@
----
-"@effect-messaging/core": minor
-"@effect-messaging/amqp": minor
-"@effect-messaging/nats": minor
----
-
-Add `newTracePerMessage` subscriber option. When enabled, each consumed message handler runs in a new root span, and the span extracted from the message headers (e.g. W3C `traceparent`) is attached as a `SpanLink` instead of being used as the parent.
-
-The option is opt-in and defaults to `false` (legacy behavior: extracted span is used as the parent of the consumer span).

--- a/.changeset/producer-span-relation.md
+++ b/.changeset/producer-span-relation.md
@@ -1,0 +1,12 @@
+---
+"@effect-messaging/core": minor
+"@effect-messaging/amqp": minor
+"@effect-messaging/nats": minor
+---
+
+Add `producerSpanRelation` subscriber option (`"parent" | "link"`). It controls how the span extracted from the message headers (e.g. W3C `traceparent`) relates to the consumer span:
+
+- `"link"` (default): each consumed message handler runs in a new root span, and the extracted span is attached as a `SpanLink` instead of being used as the parent, producing a separate but correlated trace.
+- `"parent"`: the extracted span is used as the parent, so the consumer span continues the producer's trace.
+
+**Behavior change:** the default is `"link"`. Previously the consumer span always continued the producer's trace (equivalent to `"parent"`). With this release, consumers start a new root trace per message by default and link back to the producer span. This keeps per-message traces short and bounded and avoids skewing sampling, while preserving correlation via the `SpanLink`. To restore the previous behavior, set `producerSpanRelation: "parent"`.

--- a/packages/core/src/internal/SubscriberRunner.ts
+++ b/packages/core/src/internal/SubscriberRunner.ts
@@ -29,11 +29,16 @@ import * as SubscriberOTel from "./SubscriberOTel.js"
 export interface SubscriberRunnerOptions {
   readonly handlerTimeout?: Duration.DurationInput
   /**
-   * When `true`, each message handler runs in a new **root** span, and the
-   * span extracted from the message headers is
-   * attached as a `SpanLink` instead of being used as the parent.
+   * Controls how the span extracted from the message headers relates to the
+   * consumer span.
+   *
+   * - `"link"` (default): the consumer runs in a new **root** span and the
+   *   extracted span is attached as a `SpanLink`, producing a separate (but
+   *   correlated) trace.
+   * - `"parent"`: the extracted span is used as the parent, so the consumer
+   *   span continues the producer's trace.
    */
-  readonly newTracePerMessage?: boolean
+  readonly producerSpanRelation?: "parent" | "link"
 }
 
 /**
@@ -147,21 +152,19 @@ export const runStream: <M, ES, RS, A, E, R, EX, RX>(
   return stream.pipe(
     Stream.runForEach((message) => {
       const parentSpan = config.parentSpan(message)
-      const spanOptions: Tracer.SpanOptions = config.options.newTracePerMessage
-        ? {
+      const base = {
+        kind: "consumer",
+        captureStackTrace: false,
+        attributes: config.spanAttributes(message)
+      } as const
+      const spanOptions: Tracer.SpanOptions = config.options.producerSpanRelation === "parent"
+        ? { ...base, parent: parentSpan }
+        : {
+          ...base,
           root: true,
           links: parentSpan === undefined
             ? []
-            : [{ _tag: "SpanLink", span: parentSpan, attributes: {} }],
-          kind: "consumer",
-          captureStackTrace: false,
-          attributes: config.spanAttributes(message)
-        }
-        : {
-          parent: parentSpan,
-          kind: "consumer",
-          captureStackTrace: false,
-          attributes: config.spanAttributes(message)
+            : [{ _tag: "SpanLink", span: parentSpan, attributes: {} }]
         }
       return Effect.fork(
         Effect.useSpan(

--- a/packages/core/src/internal/SubscriberRunner.ts
+++ b/packages/core/src/internal/SubscriberRunner.ts
@@ -28,6 +28,12 @@ import * as SubscriberOTel from "./SubscriberOTel.js"
  */
 export interface SubscriberRunnerOptions {
   readonly handlerTimeout?: Duration.DurationInput
+  /**
+   * When `true`, each message handler runs in a new **root** span, and the
+   * span extracted from the message headers is
+   * attached as a `SpanLink` instead of being used as the parent.
+   */
+  readonly newTracePerMessage?: boolean
 }
 
 /**
@@ -139,20 +145,32 @@ export const runStream: <M, ES, RS, A, E, R, EX, RX>(
 ) => {
   const handle = executeHandler(config)
   return stream.pipe(
-    Stream.runForEach((message) =>
-      Effect.fork(
+    Stream.runForEach((message) => {
+      const parentSpan = config.parentSpan(message)
+      const spanOptions: Tracer.SpanOptions = config.options.newTracePerMessage
+        ? {
+          root: true,
+          links: parentSpan === undefined
+            ? []
+            : [{ _tag: "SpanLink", span: parentSpan, attributes: {} }],
+          kind: "consumer",
+          captureStackTrace: false,
+          attributes: config.spanAttributes(message)
+        }
+        : {
+          parent: parentSpan,
+          kind: "consumer",
+          captureStackTrace: false,
+          attributes: config.spanAttributes(message)
+        }
+      return Effect.fork(
         Effect.useSpan(
           config.spanName(message),
-          {
-            parent: config.parentSpan(message),
-            kind: "consumer",
-            captureStackTrace: false,
-            attributes: config.spanAttributes(message)
-          },
+          spanOptions,
           (span) => handle(message, span)
         )
       )
-    ),
+    }),
     Effect.mapError((error) =>
       new SubscriberError.SubscriberError({ reason: `${config.name} failed to subscribe`, cause: error })
     )

--- a/packages/core/test/SubscriberRunner.test.ts
+++ b/packages/core/test/SubscriberRunner.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from "@effect/vitest"
-import { Deferred, Effect, Fiber, Stream, TestServices } from "effect"
+import { Deferred, Effect, Fiber, Stream, TestServices, Tracer } from "effect"
 import type * as Duration from "effect/Duration"
-import type * as Tracer from "effect/Tracer"
 import type { StreamConfig } from "../src/internal/SubscriberRunner.js"
 import * as SubscriberRunner from "../src/SubscriberRunner.js"
 
@@ -11,13 +10,18 @@ const makeConfig = <A, E = never>(opts: {
   onSuccess?: (message: string) => (response: A) => Effect.Effect<void>
   onError?: (message: string) => () => Effect.Effect<void>
   handlerTimeout?: Duration.DurationInput
+  newTracePerMessage?: boolean
+  parentSpan?: (message: string) => Tracer.AnySpan | undefined
 }): StreamConfig<string, A, E, never> => ({
   name: "TestSubscriber",
   spanName: (m: string) => `test.consume ${m}`,
-  parentSpan: () => undefined,
+  parentSpan: opts.parentSpan ?? (() => undefined),
   spanAttributes: () => ({}),
   handler: opts.handler,
-  options: opts.handlerTimeout !== undefined ? { handlerTimeout: opts.handlerTimeout } : {},
+  options: {
+    ...(opts.handlerTimeout !== undefined ? { handlerTimeout: opts.handlerTimeout } : {}),
+    ...(opts.newTracePerMessage !== undefined ? { newTracePerMessage: opts.newTracePerMessage } : {})
+  },
   onSuccess: (_message: string, _span: Tracer.Span) => opts.onSuccess?.(_message) ?? (() => Effect.void),
   onError: (_message: string, _span: Tracer.Span) => opts.onError?.(_message) ?? (() => Effect.void)
 })
@@ -178,6 +182,95 @@ describe("SubscriberRunner", { sequential: true }, () => {
 
           expect(onError).toHaveBeenCalledTimes(1)
           expect(onSuccess).toHaveBeenCalledTimes(0)
+        }).pipe(TestServices.provideLive),
+      { timeout: 10000 }
+    )
+  })
+
+  describe("newTracePerMessage option", () => {
+    const PRODUCER_TRACE_ID = "abcdef1234567890abcdef1234567890"
+    const PRODUCER_SPAN_ID = "1234567890abcdef"
+    const producerSpan = Tracer.externalSpan({
+      traceId: PRODUCER_TRACE_ID,
+      spanId: PRODUCER_SPAN_ID,
+      sampled: true
+    })
+
+    it.effect(
+      "Should attach the linked span as a SpanLink and create a root span when enabled",
+      () =>
+        Effect.gen(function*() {
+          const captured = yield* Deferred.make<Tracer.Span>()
+          const config = makeConfig({
+            handler: () =>
+              Effect.gen(function*() {
+                const span = yield* Effect.currentSpan
+                yield* Deferred.succeed(captured, span)
+                return "ok"
+              }),
+            newTracePerMessage: true,
+            parentSpan: () => producerSpan
+          })
+
+          yield* SubscriberRunner.runStream(Stream.make("msg-1"), config)
+          const capturedSpan = yield* Deferred.await(captured)
+
+          expect(capturedSpan.traceId).not.toBe(PRODUCER_TRACE_ID)
+          expect(capturedSpan.links.length).toBe(1)
+          expect(capturedSpan.links[0]!.span.traceId).toBe(PRODUCER_TRACE_ID)
+          expect(capturedSpan.links[0]!.span.spanId).toBe(PRODUCER_SPAN_ID)
+          expect(capturedSpan.links[0]!.span.sampled).toBe(true)
+          expect(capturedSpan.parent._tag).toBe("None")
+        }).pipe(TestServices.provideLive),
+      { timeout: 10000 }
+    )
+
+    it.effect(
+      "Should create a root span without links when no linked span is provided",
+      () =>
+        Effect.gen(function*() {
+          const captured = yield* Deferred.make<Tracer.Span>()
+          const config = makeConfig({
+            handler: () =>
+              Effect.gen(function*() {
+                const span = yield* Effect.currentSpan
+                yield* Deferred.succeed(captured, span)
+                return "ok"
+              }),
+            newTracePerMessage: true,
+            parentSpan: () => undefined
+          })
+
+          yield* SubscriberRunner.runStream(Stream.make("msg-1"), config)
+          const capturedSpan = yield* Deferred.await(captured)
+
+          expect(capturedSpan.links.length).toBe(0)
+          expect(capturedSpan.parent._tag).toBe("None")
+        }).pipe(TestServices.provideLive),
+      { timeout: 10000 }
+    )
+
+    it.effect(
+      "Should use the linked span as parent when option is disabled (default)",
+      () =>
+        Effect.gen(function*() {
+          const captured = yield* Deferred.make<Tracer.Span>()
+          const config = makeConfig({
+            handler: () =>
+              Effect.gen(function*() {
+                const span = yield* Effect.currentSpan
+                yield* Deferred.succeed(captured, span)
+                return "ok"
+              }),
+            parentSpan: () => producerSpan
+          })
+
+          yield* SubscriberRunner.runStream(Stream.make("msg-1"), config)
+          const capturedSpan = yield* Deferred.await(captured)
+
+          expect(capturedSpan.traceId).toBe(PRODUCER_TRACE_ID)
+          expect(capturedSpan.links.length).toBe(0)
+          expect(capturedSpan.parent._tag).toBe("Some")
         }).pipe(TestServices.provideLive),
       { timeout: 10000 }
     )

--- a/packages/core/test/SubscriberRunner.test.ts
+++ b/packages/core/test/SubscriberRunner.test.ts
@@ -10,7 +10,7 @@ const makeConfig = <A, E = never>(opts: {
   onSuccess?: (message: string) => (response: A) => Effect.Effect<void>
   onError?: (message: string) => () => Effect.Effect<void>
   handlerTimeout?: Duration.DurationInput
-  newTracePerMessage?: boolean
+  producerSpanRelation?: "parent" | "link"
   parentSpan?: (message: string) => Tracer.AnySpan | undefined
 }): StreamConfig<string, A, E, never> => ({
   name: "TestSubscriber",
@@ -20,7 +20,7 @@ const makeConfig = <A, E = never>(opts: {
   handler: opts.handler,
   options: {
     ...(opts.handlerTimeout !== undefined ? { handlerTimeout: opts.handlerTimeout } : {}),
-    ...(opts.newTracePerMessage !== undefined ? { newTracePerMessage: opts.newTracePerMessage } : {})
+    ...(opts.producerSpanRelation !== undefined ? { producerSpanRelation: opts.producerSpanRelation } : {})
   },
   onSuccess: (_message: string, _span: Tracer.Span) => opts.onSuccess?.(_message) ?? (() => Effect.void),
   onError: (_message: string, _span: Tracer.Span) => opts.onError?.(_message) ?? (() => Effect.void)
@@ -187,7 +187,7 @@ describe("SubscriberRunner", { sequential: true }, () => {
     )
   })
 
-  describe("newTracePerMessage option", () => {
+  describe("producerSpanRelation option", () => {
     const PRODUCER_TRACE_ID = "abcdef1234567890abcdef1234567890"
     const PRODUCER_SPAN_ID = "1234567890abcdef"
     const producerSpan = Tracer.externalSpan({
@@ -197,7 +197,7 @@ describe("SubscriberRunner", { sequential: true }, () => {
     })
 
     it.effect(
-      "Should attach the linked span as a SpanLink and create a root span when enabled",
+      "Should attach the producer span as a SpanLink and create a root span when set to \"link\"",
       () =>
         Effect.gen(function*() {
           const captured = yield* Deferred.make<Tracer.Span>()
@@ -208,7 +208,7 @@ describe("SubscriberRunner", { sequential: true }, () => {
                 yield* Deferred.succeed(captured, span)
                 return "ok"
               }),
-            newTracePerMessage: true,
+            producerSpanRelation: "link",
             parentSpan: () => producerSpan
           })
 
@@ -226,7 +226,7 @@ describe("SubscriberRunner", { sequential: true }, () => {
     )
 
     it.effect(
-      "Should create a root span without links when no linked span is provided",
+      "Should create a root span without links when no producer span is provided",
       () =>
         Effect.gen(function*() {
           const captured = yield* Deferred.make<Tracer.Span>()
@@ -237,7 +237,7 @@ describe("SubscriberRunner", { sequential: true }, () => {
                 yield* Deferred.succeed(captured, span)
                 return "ok"
               }),
-            newTracePerMessage: true,
+            producerSpanRelation: "link",
             parentSpan: () => undefined
           })
 
@@ -251,7 +251,33 @@ describe("SubscriberRunner", { sequential: true }, () => {
     )
 
     it.effect(
-      "Should use the linked span as parent when option is disabled (default)",
+      "Should use the producer span as parent when set to \"parent\"",
+      () =>
+        Effect.gen(function*() {
+          const captured = yield* Deferred.make<Tracer.Span>()
+          const config = makeConfig({
+            handler: () =>
+              Effect.gen(function*() {
+                const span = yield* Effect.currentSpan
+                yield* Deferred.succeed(captured, span)
+                return "ok"
+              }),
+            producerSpanRelation: "parent",
+            parentSpan: () => producerSpan
+          })
+
+          yield* SubscriberRunner.runStream(Stream.make("msg-1"), config)
+          const capturedSpan = yield* Deferred.await(captured)
+
+          expect(capturedSpan.traceId).toBe(PRODUCER_TRACE_ID)
+          expect(capturedSpan.links.length).toBe(0)
+          expect(capturedSpan.parent._tag).toBe("Some")
+        }).pipe(TestServices.provideLive),
+      { timeout: 10000 }
+    )
+
+    it.effect(
+      "Should default to \"link\" (new root span + SpanLink) when option is unset",
       () =>
         Effect.gen(function*() {
           const captured = yield* Deferred.make<Tracer.Span>()
@@ -268,9 +294,10 @@ describe("SubscriberRunner", { sequential: true }, () => {
           yield* SubscriberRunner.runStream(Stream.make("msg-1"), config)
           const capturedSpan = yield* Deferred.await(captured)
 
-          expect(capturedSpan.traceId).toBe(PRODUCER_TRACE_ID)
-          expect(capturedSpan.links.length).toBe(0)
-          expect(capturedSpan.parent._tag).toBe("Some")
+          expect(capturedSpan.traceId).not.toBe(PRODUCER_TRACE_ID)
+          expect(capturedSpan.links.length).toBe(1)
+          expect(capturedSpan.links[0]!.span.traceId).toBe(PRODUCER_TRACE_ID)
+          expect(capturedSpan.parent._tag).toBe("None")
         }).pipe(TestServices.provideLive),
       { timeout: 10000 }
     )


### PR DESCRIPTION
## Summary

Adds a `producerSpanRelation` option to `SubscriberRunnerOptions` that controls how the span extracted from the message headers (e.g. W3C `traceparent`) relates to the consumer span:

- **`"link"` (default)**: each consumed message handler runs in a new **root** span, and the extracted producer span is attached as a `SpanLink` instead of being used as the parent — producing a separate but correlated trace.
- **`"parent"`**: the extracted span is used as the parent, so the consumer span continues the producer's trace (legacy behavior).

## Motivation

Long-running message-driven workflows previously inherited the producer's trace, which produced extremely long traces and skewed sampling. Starting a new root span per message — while keeping the producer span linked — gives clean, bounded traces per consumption while preserving correlation.

## Behavior change

The default is `"link"`. Previously the consumer span always continued the producer's trace (equivalent to `"parent"`). With this release, consumers start a new root trace per message by default and link back to the producer span. To restore the previous behavior, set `producerSpanRelation: "parent"`.

## Changes

- `packages/core/src/internal/SubscriberRunner.ts`: add `producerSpanRelation` option and branch span options on it
- The option flows automatically into `AMQPSubscriberOptions`, `NATSSubscriberOptions`, `JetStreamSubscriberOptions` (they extend `SubscriberRunnerOptions`)
- Tests covering all cases (`"link"` with/without producer span, `"parent"`, and unset defaulting to `"link"`)
- Changeset: minor bump for `core`, `amqp`, `nats`

## Usage

```ts
// Default: new root trace per message, linked to the producer span
SubscriberRunner.runStream(stream, { ...config })

// Opt back into continuing the producer's trace
SubscriberRunner.runStream(stream, {
  ...config,
  options: { producerSpanRelation: "parent" }
})
```
