### PR TITLE
docs(changeset): document amqplib heartbeat:0 breaking change

### DIFF
--- a/.changeset/upgrade-broker-libs.md
+++ b/.changeset/upgrade-broker-libs.md
@@ -1,9 +1,12 @@
 ---
-"@effect-messaging/amqp": patch
+"@effect-messaging/amqp": minor
 "@effect-messaging/nats": patch
 ---
 
 Upgrade messaging broker libraries to their latest versions.
 
-- `@effect-messaging/amqp`: bump `amqplib` from `0.10.9` to `2.0.1`. `amqplib` now ships its own type definitions, so the `@types/amqplib` dev dependency has been removed.
+- `@effect-messaging/amqp`: bump `amqplib` from `0.10.9` to `2.0.1` (the `peerDependency` is now `^2.0.1`, so consumers must upgrade `amqplib` to `2.x`). `amqplib` now ships its own type definitions, so the `@types/amqplib` dev dependency was removed in favour of `@types/node`.
+
+  **Behavioral change (amqplib v2.0.0):** passing `heartbeat: 0` in the connection options now disables heartbeats entirely, overriding any value suggested by the server. Previously `0` meant "no preference" and the server's suggested value was used. To keep the old behavior, omit `heartbeat` (or pass `null`) instead of `0`.
+
 - `@effect-messaging/nats`: bump `@nats-io/jetstream`, `@nats-io/nats-core`, and `@nats-io/transport-node` from `3.3.1` to `3.4.0`.


### PR DESCRIPTION
Follow-up to #152 (merged). That PR's changeset was still `patch` and didn't mention the one consumer-visible behavioral change from the `amqplib` 0.10 → 2.0 major bump.

## Changes
- Bump `@effect-messaging/amqp` changeset from `patch` → `minor` (the `amqplib` peer dependency now requires `^2.0.1`, a major bump consumers must adopt).
- Document the **amqplib v2.0.0 behavioral change**: `heartbeat: 0` now disables heartbeats instead of meaning "use the server's suggested value". To preserve the old behavior, omit `heartbeat` or pass `null`.

## Breaking-change audit (0.10.9 → 2.0.1)
All other breaking changes were verified as **not affecting** this package:
- min Node v18 — repo `engines.node` is `24`
- `channel.get()` now rejects with a proper `Error` — our `wrapChannelMethod` wraps any rejection shape
- `url-parse` → WHATWG URL API — standard AMQP URLs parse identically and are forwarded as-is
- TLS SNI / `buffer-more-ints` removal — internal only

Only `heartbeat: 0` is consumer-visible, hence this documentation.