### PR TITLE
fix: downgrade producerSpanRelation changeset to patch

### DIFF
--- a/.changeset/producer-span-relation.md
+++ b/.changeset/producer-span-relation.md
@@ -1,7 +1,7 @@
 ---
-"@effect-messaging/core": minor
-"@effect-messaging/amqp": minor
-"@effect-messaging/nats": minor
+"@effect-messaging/core": patch
+"@effect-messaging/amqp": patch
+"@effect-messaging/nats": patch
 ---
 
 Add `producerSpanRelation` subscriber option (`"parent" | "link"`). It controls how the span extracted from the message headers (e.g. W3C `traceparent`) relates to the consumer span:


### PR DESCRIPTION
## Problem

The release PR bumps `@effect-messaging/amqp` and `@effect-messaging/nats` to **1.0.0**.

## Root cause

amqp/nats declare `@effect-messaging/core` as a `peerDependency` (`workspace:^`). The `producer-span-relation` changeset bumps core with a `minor` (`0.2.42 -> 0.3.0`). For `0.x` versions the caret range `^0.2.42` excludes `0.3.0`, so changesets treats the peer dependency as out-of-range and forces a **major** bump on amqp/nats -> 1.0.0.

## Fix

Downgrade the `producer-span-relation` changeset from `minor` to `patch`. A patch keeps core (`0.2.43`) within the `^0.2.x` peer range, so amqp/nats no longer cascade to a major.

## Resulting versions

| | core | amqp | nats |
|---|---|---|---|
| before | 0.3.0 | 1.0.0 | 1.0.0 |
| after | 0.2.43 | 0.6.5 | 0.7.6 |